### PR TITLE
Added a method for uninstalling constraints on a view.

### DIFF
--- a/Snappy/ConstraintMaker.swift
+++ b/Snappy/ConstraintMaker.swift
@@ -97,4 +97,11 @@ public class ConstraintMaker {
         }
         LayoutConstraint.setLayoutConstraints(layoutConstraints, installedOnView: view)
     }
+    
+    internal class func removeConstraints(view: View) {
+        for existingLayoutConstraint in LayoutConstraint.layoutConstraintsInstalledOnView(view) {
+            existingLayoutConstraint.constraint?.uninstall()
+        }
+        LayoutConstraint.setLayoutConstraints([], installedOnView: view)
+    }
 }

--- a/Snappy/View+Snappy.swift
+++ b/Snappy/View+Snappy.swift
@@ -54,9 +54,11 @@ public extension View {
         ConstraintMaker.remakeConstraints(self, block: block)
     }
     
-    public func snp_uninstallConstraints() {
+    public func snp_removeConstraints() {
         for existingLayoutConstraint in LayoutConstraint.layoutConstraintsInstalledOnView(self) {
             existingLayoutConstraint.constraint?.uninstall()
         }
+        
+        LayoutConstraint.setLayoutConstraints([], installedOnView: self)
     }
 }

--- a/Snappy/View+Snappy.swift
+++ b/Snappy/View+Snappy.swift
@@ -53,4 +53,10 @@ public extension View {
     public func snp_remakeConstraints(block: (maker: ConstraintMaker) -> ()) {
         ConstraintMaker.remakeConstraints(self, block: block)
     }
+    
+    public func snp_uninstallConstraints() {
+        for existingLayoutConstraint in LayoutConstraint.layoutConstraintsInstalledOnView(self) {
+            existingLayoutConstraint.constraint?.uninstall()
+        }
+    }
 }

--- a/Snappy/View+Snappy.swift
+++ b/Snappy/View+Snappy.swift
@@ -55,10 +55,6 @@ public extension View {
     }
     
     public func snp_removeConstraints() {
-        for existingLayoutConstraint in LayoutConstraint.layoutConstraintsInstalledOnView(self) {
-            existingLayoutConstraint.constraint?.uninstall()
-        }
-        
-        LayoutConstraint.setLayoutConstraints([], installedOnView: self)
+        ConstraintMaker.removeConstraints(self)
     }
 }


### PR DESCRIPTION
I've been playing around with Size Classes and Snappy and ran into a very interesting issue. I wanted to create a simple blue view in portrait that would turn into a blue and green view in landscape. The blue and green views would be dependent upon each other in their constraints (blue view width = green view width with multiplier 2.0). This is extremely easy to set up, but when trying to remake the constraints, I ran into unsatisfied constraint issues depending on the order in which I called remake. I have created a sample project that reproduces the issue.

* https://github.com/cnoon/Snappy-Remake-Constraints

In the `remakeConstraintsForLandscapeLayout` method, I have two approaches written. One which works and one which throws unsatisfied constraint errors. I finally figured out that the issue was that `remakeConstraints` ends up `addingConstraints` on the `install` method which is trying to satisfy all the current constraints. It doesn't work properly in all situations because you can only `remakeConstraints` one view at a time. What I need to do is to clear all the constraints from both the `blueView` and `greenView` before I start to `remakeConstraints`. Unfortunately though that is very difficult to do and is impossible with Snappy's current implementation.

I wanted to be able to clear out the Snappy constraints on both those views before remaking constraints like so:

```
for view in [self.blueView, self.greenView] {
    for existingLayoutConstraint in LayoutConstraint.layoutConstraintsInstalledOnView(view) {
        existingLayoutConstraint.constraint?.uninstall()
    }
}
```

The problem as I'm sure you can already see is that the `LayoutConstraint` class is internal to Snappy. I totally see why you designed it that way and I think it should stay. Then I tried the following which works just fine in this simple example, but definitely won't work in much more complicated examples because I don't want to clear out all the constraints on `self.view`, only the ones related to `self.blueView` and `self.greenView`.

```
for constraint in self.view.constraints() as [NSLayoutConstraint] {
    self.view.removeConstraint(constraint)
}
```

What I think would be a great addition would be something like the following:

```
// In View+Snappy.swift
public extension View {
    public func snp_uninstallConstraints() {
        for existingLayoutConstraint in LayoutConstraint.layoutConstraintsInstalledOnView(self) {
            existingLayoutConstraint.constraint?.uninstall()
        }
    }
}

// In RootViewController.swift - remakeConstraintsForLandscapeLayout
self.blueView.snp_uninstallConstraints()
self.greenView.snp_uninstallConstraints()
```

This would allow me to uninstall all my constraints before I start remaking constraints for views that depend on each other. I'm curious to get your thoughts. I think this could really help in very complicated examples. The actual layout code I was using when I discovered this was actually much more complicated. I just simplified it here to make it easy to follow.